### PR TITLE
Update accelerator to CommandOrControl+Q because windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ app.on('ready', function () {
   var contextMenu = Menu.buildFromTemplate([
     {
       label: 'Quit',
-      accelerator: 'Command+Q',
+      accelerator: 'CommandOrControl+Q',
       click: function () { app.quit() }
     }
   ])

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var app = require('app')  // Module to control application life.
-var BrowserWindow = require('browser-window')
 var Tray = require('tray')
 var Menu = require('menu')
 var moonmoji = require('moonmoji')
@@ -19,7 +18,6 @@ var phases = {
   'Waning Crescent': '196'
 }
 
-var mainWindow = null
 var appIcon = null
 
 // This method will be called when Electron has done everything


### PR DESCRIPTION
This is pretty neat @bcomnes :)

It works on windows too! But it was throwing this error in the console:

```
[10248:0521/170911:WARNING:accelerator_util.cc(185)] Invalid accelerator token: command
```

It looks like electron has `CommandOrControl` to deal with cross platform shortcuts.
